### PR TITLE
update python 3.11 image and pin numpy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
           runtimes='3.9 3.10 3.11'
           for runtime in ${runtimes}; do
             docker build \
-              --platform=linux/amd6--platform=linux/amd644 \
+              --platform=linux/amd64 \
               --build-arg GDAL_VERSION=${{ matrix.gdal-version }} \
               --build-arg RUNTIME_VERSION=${runtime} \
               -f dockerfiles/runtimes/python \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,10 @@ jobs:
       - name: Build Runtime and Push
         if: github.ref == 'refs/heads/master'
         run: |
-          runtimes='3.9 3.10 3.11-preview'
+          runtimes='3.9 3.10 3.11'
           for runtime in ${runtimes}; do
             docker build \
-              --platform=linux/amd64 \
+              --platform=linux/amd6--platform=linux/amd644 \
               --build-arg GDAL_VERSION=${{ matrix.gdal-version }} \
               --build-arg RUNTIME_VERSION=${runtime} \
               -f dockerfiles/runtimes/python \

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Runtimes images:
   - Python (based on `public.ecr.aws/lambda/python:{version}`)
     - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.9**
     - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
-    - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
+    - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.11**
 
 see: https://github.com/lambgeo/docker-lambda/pkgs/container/lambda-gdal
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ Runtimes images:
   - Python (based on `public.ecr.aws/lambda/python:{version}`)
     - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.9**
     - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
-
-  - Python 3.11-preview (based on `public.ecr.aws/lambda/python:3.11-preview`)
-    - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.11-preview**
+    - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
 
 see: https://github.com/lambgeo/docker-lambda/pkgs/container/lambda-gdal
 
@@ -63,7 +61,7 @@ ENV \
 RUN cd $PACKAGE_PREFIX && zip -r9q /tmp/package.zip *
 ```
 
-If you are working with **python3.9|3.10**, you can use lambgeo pre-build docker images:
+If you are working with **python3.9|3.10|3.11**, you can use lambgeo pre-build docker images:
 
 ```Dockerfile
 FROM ghcr.io/lambgeo/lambda-gdal:3.6-python3.10
@@ -124,9 +122,9 @@ Starting with gdal3.1 (PROJ 7.1), you can set `PROJ_NETWORK=ON` to use remote gr
 
 # AWS Lambda Layers
 
-gdal | amazonlinux version| size (Mb)| unzipped size (Mb)| arn
-  ---|                 ---|       ---|                ---| ---
-3.6  |                   2|      30.5|               73.4| arn:aws:lambda:{REGION}:524387336408:layer:gdal36:{VERSION}
+| gdal | amazonlinux version | size (Mb) | unzipped size (Mb) | arn                                                         |
+| ---- | ------------------- | --------- | ------------------ | ----------------------------------------------------------- |
+| 3.6  | 2                   | 30.5      | 73.4               | arn:aws:lambda:{REGION}:524387336408:layer:gdal36:{VERSION} |
 
 see [/layer.json](/layer.json) for the list of arns
 
@@ -147,13 +145,13 @@ cat layer.json| jq '.[] | select(.region == "us-west-2")'
 
 #### archived layers
 
-gdal | amazonlinux version| size (Mb)| unzipped size (Mb)| arn
-  ---|                 ---|       ---|                ---| ---
-3.5  |                   2|      30.5|               73.4| arn:aws:lambda:{REGION}:524387336408:layer:gdal35:{VERSION}
-3.3  |                   2|      27.7|               67.3| arn:aws:lambda:{REGION}:524387336408:layer:gdal33-al2:{VERSION}
-3.2  |                   2|      26.7|               64.6| arn:aws:lambda:{REGION}:524387336408:layer:gdal32-al2:{VERSION}
-3.1  |                   2|      25.8|                 61| arn:aws:lambda:{REGION}:524387336408:layer:gdal31-al2:{VERSION}
-2.4  |                   2|      19.5|               63.6| arn:aws:lambda:{REGION}:524387336408:layer:gdal24-al2:{VERSION}
+| gdal | amazonlinux version | size (Mb) | unzipped size (Mb) | arn                                                             |
+| ---- | ------------------- | --------- | ------------------ | --------------------------------------------------------------- |
+| 3.5  | 2                   | 30.5      | 73.4               | arn:aws:lambda:{REGION}:524387336408:layer:gdal35:{VERSION}     |
+| 3.3  | 2                   | 27.7      | 67.3               | arn:aws:lambda:{REGION}:524387336408:layer:gdal33-al2:{VERSION} |
+| 3.2  | 2                   | 26.7      | 64.6               | arn:aws:lambda:{REGION}:524387336408:layer:gdal32-al2:{VERSION} |
+| 3.1  | 2                   | 25.8      | 61                 | arn:aws:lambda:{REGION}:524387336408:layer:gdal31-al2:{VERSION} |
+| 2.4  | 2                   | 19.5      | 63.6               | arn:aws:lambda:{REGION}:524387336408:layer:gdal24-al2:{VERSION} |
 
 see [/archived_layer.json](/archived_layer.json) for the list of arns
 

--- a/dockerfiles/runtimes/python
+++ b/dockerfiles/runtimes/python
@@ -12,13 +12,13 @@ ENV \
   LC_ALL=en_US.UTF-8 \
   CFLAGS="--std=c99"
 
-RUN yum install -y gcc gcc-c++
+RUN yum install -y gcc gcc-c++ && \
+    yum clean all && \
+    rm -rf /var/cache/yum /var/lib/yum/history
+
 RUN \
     python -m pip install pip -U \
-    && python -m pip install cython numpy wheel --no-binary numpy
-
-RUN yum clean all \
-    && rm -rf /var/cache/yum /var/lib/yum/history
+    && python -m pip install cython numpy==1.25 wheel --no-binary numpy
 
 # The PREFIX should be the same as in gdal{version}:latest
 # When building rasterio, setup.py will get libs directoy from gdal-config


### PR DESCRIPTION
1. Update image referenced for python 3.11
2. Pin numpy to 1.25.x, as 1.26.x requires gcc >= 8, where as the image only has gcc 7
3. Moved yum clean to same docker command as install, so it actually cleans up in the same layer