### PR TITLE
Add flags to cmake commands so that the libraries in /opt/lib are linked before others

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -384,8 +384,8 @@ RUN mkdir /tmp/gdal \
     -DGDAL_USE_LERC_INTERNAL=OFF \
     -DLERC_INCLUDE_DIR=$PREFIX/include \
     -DLERC_LIBRARY=$PREFIX/lib/libLercLib.so \
-    -DSQLITE3_INCLUDE_DIR=$PREFIX/include \
-    -DSQLITE3_LIBRARY=$PREFIX/lib/libsqlite3.so \
+    -DSQLite3_INCLUDE_DIR=$PREFIX/include \
+    -DSQLite3_LIBRARY=$PREFIX/lib/libsqlite3.so \
     -DPNG_PNG_INCLUDE_DIR=$PREFIX/include \
     -DPNG_LIBRARY_RELEASE=$PREFIX/lib/libpng.so \
     -DBUILD_PYTHON_BINDINGS=OFF \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -101,6 +101,7 @@ RUN mkdir /tmp/jpeg \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
   && make -j $(nproc) --silent && make install \
@@ -132,6 +133,7 @@ RUN mkdir /tmp/lerc \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
   && make -j $(nproc) --silent && make install \
@@ -175,6 +177,7 @@ RUN mkdir /tmp/openjpeg \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
   && make -j $(nproc) --silent && make install \
@@ -190,6 +193,7 @@ RUN mkdir /tmp/geos \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
   && make -j $(nproc) --silent && make install \
@@ -217,6 +221,7 @@ RUN mkdir /tmp/proj && mkdir /tmp/proj/data \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
     -DCMAKE_INSTALL_INCLUDEDIR:PATH=include \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DBUILD_TESTING=OFF \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
@@ -248,6 +253,7 @@ RUN mkdir /tmp/blosc \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
     -DCMAKE_INSTALL_RPATH="$ORIGIN" \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
     -DBUILD_SHARED=ON \
@@ -369,6 +375,7 @@ RUN mkdir /tmp/gdal \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_PREFIX:PATH=$PREFIX \
     -DCMAKE_INSTALL_LIBDIR:PATH=lib \
+    -DCMAKE_LIBRARY_PATH:PATH=$PREFIX/lib \
     -DCMAKE_C_FLAGS="-O2 -Wl,-S" \
     -DCMAKE_CXX_FLAGS="-O2 -Wl,-S" \
     -DGDAL_SET_INSTALL_RELATIVE_RPATH=ON \

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -384,6 +384,8 @@ RUN mkdir /tmp/gdal \
     -DGDAL_USE_LERC_INTERNAL=OFF \
     -DLERC_INCLUDE_DIR=$PREFIX/include \
     -DLERC_LIBRARY=$PREFIX/lib/libLercLib.so \
+    -DSQLITE3_INCLUDE_DIR=$PREFIX/include \
+    -DSQLITE3_LIBRARY=$PREFIX/lib/libsqlite3.so \
     -DPNG_PNG_INCLUDE_DIR=$PREFIX/include \
     -DPNG_LIBRARY_RELEASE=$PREFIX/lib/libpng.so \
     -DBUILD_PYTHON_BINDINGS=OFF \

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,7 +21,8 @@ if [[ ! "$(ogrinfo --formats | grep 'DXF')" ]]; then echo "DXF NOK" && exit 1; f
 echo "OK"
 
 echo "Checking sqlite build"
-if [[ ! "$(ldd $PREFIX/bin/gdalwarp | grep '/opt/bin/../lib/libsqlite3')" ]]; then echo "libsql NOK" && exit 1; fi
+if [[ ! "$(ldd $PREFIX/bin/gdalwarp | grep '/opt/bin/../lib/libsqlite3')" ]]; then echo "gdalwarp libsql NOK" && exit 1; fi
+if [[ ! "$(ldd $PREFIX/lib/libgdal.so | grep '/opt/lib/libsqlite3')" ]]; then echo "libgdal libsql NOK" && exit 1; fi
 echo "OK"
 
 echo "Checking OGR"


### PR DESCRIPTION
Fixes https://github.com/lambgeo/docker-lambda/issues/71
I have also added a test for the correct linking to sqlite in libgdal.so

The test is still failing even after adding the flags, so need to investigate why.