### PR TITLE
Run patchelf on libgdal

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -399,6 +399,7 @@ RUN rm -f $PREFIX/lib/libturbojpeg.so* \
 
 # FIX
 RUN for i in $PREFIX/bin/*; do patchelf --force-rpath --set-rpath '$ORIGIN/../lib' $i; done
+RUN patchelf --force-rpath --set-rpath '$ORIGIN' $PREFIX/lib/libgdal.so
 
 # Build final image
 FROM public.ecr.aws/lambda/provided:al2 as runner

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -21,7 +21,8 @@ if [[ ! "$(ogrinfo --formats | grep 'DXF')" ]]; then echo "DXF NOK" && exit 1; f
 echo "OK"
 
 echo "Checking sqlite build"
-if [[ ! "$(ldd $PREFIX/bin/gdalwarp | grep '/opt/bin/../lib/libsqlite3')" ]]; then echo "libsql NOK" && exit 1; fi
+if [[ ! "$(ldd $PREFIX/bin/gdalwarp | grep '/opt/bin/../lib/libsqlite3')" ]]; then echo "gdalwarp libsql NOK" && exit 1; fi
+if [[ ! "$(ldd $PREFIX/lib/libgdal.so | grep '/opt/lib/libsqlite3')" ]]; then echo "libgdal libsql NOK" && exit 1; fi
 echo "OK"
 
 echo "Checking OGR"


### PR DESCRIPTION
Fixes #71 

I'm a bit out of my depth on this issue, but this seems to work. Unsure if we should also do this for other libs - I don't seem to have a problem with other libs though.

I've pushed the image at `ghcr.io/jasongi/lambda-gdal:3.8-python3.11` if you want to try it.