### PR TITLE
update geos, proj, and gdal versions; fix issue with which tag gets used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ on:
   pull_request:
 
 env:
-  GDAL_VERSION: 3.8.2
+  GDAL_VERSION: 3.8.3
   GDAL_VERSION_TAG: 3.8
 
 jobs:

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -181,7 +181,7 @@ RUN mkdir /tmp/openjpeg \
   && rm -rf /tmp/openjpeg
 
 # geos
-ENV GEOS_VERSION=3.11.2
+ENV GEOS_VERSION=3.12.1
 RUN mkdir /tmp/geos \
   && curl -sfL https://github.com/libgeos/geos/archive/refs/tags/${GEOS_VERSION}.tar.gz | tar zxf - -C /tmp/geos --strip-components=1 \
   && cd /tmp/geos \
@@ -207,7 +207,7 @@ RUN mkdir /tmp/geos \
 #   && make -j $(nproc) --silent && make install \
 #   && rm -rf /tmp/proj
 
-ENV PROJ_VERSION=9.2.0
+ENV PROJ_VERSION=9.3.1
 RUN mkdir /tmp/proj && mkdir /tmp/proj/data \
   && curl -sfL https://github.com/OSGeo/proj/archive/${PROJ_VERSION}.tar.gz | tar zxf - -C /tmp/proj --strip-components=1 \
   && cd /tmp/proj \

--- a/dockerfiles/runtimes/nodejs
+++ b/dockerfiles/runtimes/nodejs
@@ -1,7 +1,7 @@
-ARG GDAL_VERSION
+ARG GDAL_VERSION_TAG
 ARG RUNTIME_VERSION
 
-FROM ghcr.io/lambgeo/lambda-gdal:${GDAL_VERSION} as gdal
+FROM ghcr.io/lambgeo/lambda-gdal:${GDAL_VERSION_TAG} as gdal
 
 FROM public.ecr.aws/lambda/nodejs:${RUNTIME_VERSION}
 

--- a/dockerfiles/runtimes/python
+++ b/dockerfiles/runtimes/python
@@ -1,7 +1,7 @@
-ARG GDAL_VERSION
+ARG GDAL_VERSION_TAG
 ARG RUNTIME_VERSION
 
-FROM ghcr.io/lambgeo/lambda-gdal:${GDAL_VERSION} as gdal
+FROM ghcr.io/lambgeo/lambda-gdal:${GDAL_VERSION_TAG} as gdal
 
 FROM public.ecr.aws/lambda/python:${RUNTIME_VERSION}
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ docker buildx build \
 
 docker buildx build \
     --platform=linux/amd64 \
-    --build-arg GDAL_VERSION=${GDAL_VERSION} \
+    --build-arg GDAL_VERSION_TAG=${GDAL_VERSION_TAG} \
     --build-arg RUNTIME_VERSION=${RUNTIME_VERSION} \
     -f dockerfiles/runtimes/${RUNTIME} \
     -t ghcr.io/lambgeo/lambda-gdal:${GDAL_VERSION_TAG}-${RUNTIME}${RUNTIME_VERSION} .


### PR DESCRIPTION
1. Update versions of geos, proj, and gdal
2. Correctly use the "tag" of the image rather than the full gdal version in the scripts and dockerfiles. I'm unsure how this ever worked.