### PR TITLE
Pv/gdal 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
 
       - name: Install dependencies
         run: |
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build Runtime and Push Python <=3.11 with yum
         run: |
-          runtimes='3.9 3.10 3.11'
+          runtimes='3.10 3.11'
           for runtime in ${runtimes}; do
             docker build \
               --platform=linux/amd64 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
   pull_request:
 
 env:
-  GDAL_VERSION: 3.8.3
-  GDAL_VERSION_TAG: 3.8
+  GDAL_VERSION: 3.10.2
+  GDAL_VERSION_TAG: 3.10
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ on:
   pull_request:
 
 env:
-  GDAL_VERSION: 3.10.2
-  GDAL_VERSION_TAG: 3.10
+  GDAL_VERSION: 3.9.3 # 3.10.2
+  GDAL_VERSION_TAG: 3.9
 
 jobs:
   build:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 - Add support for Python 3.12 and 3.13
 - Update deploy.py script compatible runtimes list to currently-available runtimes
+- update versions:
+  - GDAL: 3.10.2 "Gulf of Mexico"
 
 ## 2024-02-02.patch1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for Python 3.12 and 3.13
+- Remove support for Python 3.9
 - Update deploy.py script compatible runtimes list to currently-available runtimes
 
 ## 2024-02-02.patch1

--- a/README.md
+++ b/README.md
@@ -18,17 +18,23 @@
 
 Based on `public.ecr.aws/lambda/provided:al2` (AmazonLinux 2)
 
-- GDAL 3.8.3
-  - **ghcr.io/lambgeo/lambda-gdal:3.8** (Fev 2024)
+- GDAL 3.10.2
+  - **ghcr.io/lambgeo/lambda-gdal:3.10.2** (Feb 2025)
 
 Runtimes images:
 
 - Python (based on `public.ecr.aws/lambda/python:{version}`)
+  - **ghcr.io/lambgeo/lambda-gdal:3.10-python3.9**
+  - **ghcr.io/lambgeo/lambda-gdal:3.10-python3.10**
+  - **ghcr.io/lambgeo/lambda-gdal:3.10-python3.11**
+  - **ghcr.io/lambgeo/lambda-gdal:3.10-python3.12**
+  - **ghcr.io/lambgeo/lambda-gdal:3.10-python3.13**
+
+**archived**
+  - **ghcr.io/lambgeo/lambda-gdal:3.8**
   - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.9**
   - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.10**
   - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.11**
-
-**archived**
   - **ghcr.io/lambgeo/lambda-gdal:3.6**
   - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.9**
   - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
@@ -43,7 +49,7 @@ see: <https://github.com/lambgeo/docker-lambda/pkgs/container/lambda-gdal>
 #### 1. Create Dockerfile
 
 ```Dockerfile
-FROM ghcr.io/lambgeo/lambda-gdal:3.8 AS gdal
+FROM ghcr.io/lambgeo/lambda-gdal:3.10 AS gdal
 
 # We use the official AWS Lambda image
 FROM public.ecr.aws/lambda/{RUNTIME: python|node|go...}:{RUNTIME version}

--- a/README.md
+++ b/README.md
@@ -24,11 +24,13 @@ Based on `public.ecr.aws/lambda/provided:al2` (AmazonLinux 2)
 Runtimes images:
 
 - Python (based on `public.ecr.aws/lambda/python:{version}`)
-  - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.9**
   - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.10**
   - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.11**
+  - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.12**
+  - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.13**
 
 **archived**
+  - **ghcr.io/lambgeo/lambda-gdal:3.8-python3.9**
   - **ghcr.io/lambgeo/lambda-gdal:3.6**
   - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.9**
   - **ghcr.io/lambgeo/lambda-gdal:3.6-python3.10**
@@ -69,7 +71,7 @@ ENV \
 RUN cd $PACKAGE_PREFIX && zip -r9q /tmp/package.zip *
 ```
 
-If you are working with **python3.9|3.10|3.11|3.12|3.13**, you can use lambgeo pre-build docker images:
+If you are working with **python3.10|3.11|3.12|3.13**, you can use lambgeo pre-build docker images:
 
 ```Dockerfile
 FROM ghcr.io/lambgeo/lambda-gdal:3.8-python3.10

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Based on `public.ecr.aws/lambda/provided:al2` (AmazonLinux 2)
 
 see: <https://github.com/lambgeo/docker-lambda/pkgs/container/lambda-gdal>
 
-### Creating Lambda packages
+## Creating Lambda packages
 
 ### Using
 
@@ -138,7 +138,7 @@ Other variables:
 
 Starting with gdal3.1 (PROJ 7.1), you can set `PROJ_NETWORK=ON` to use [remote grids](https://proj.org/usage/network.html).
 
-# AWS Lambda Layers
+## AWS Lambda Layers
 
 | gdal | amazonlinux version | size (Mb) | unzipped size (Mb) | arn                                                         |
 | ---- | ------------------- | --------- | ------------------ | ----------------------------------------------------------- |
@@ -146,7 +146,7 @@ Starting with gdal3.1 (PROJ 7.1), you can set `PROJ_NETWORK=ON` to use [remote g
 
 see [/layer.json](/layer.json) for the list of arns
 
-### Find the arn version
+### Find the ARN version
 
 ```bash
 cat layer.json| jq '.[] | select(.region == "us-west-2")'
@@ -286,3 +286,13 @@ package.zip
   - **GDAL_DATA:** /opt/share/gdal
   - **PROJ_LIB:** /opt/share/proj
 - lambda handler: `handler.handler`
+
+## Building locally for testing
+
+To run the image build locally, execute the script `scripts/build.sh` with
+three arguments of (1) the GDAL version, (2) the runtime platform, and (3)
+the version of the runtime platform:
+
+```commandline
+./scripts/build.sh 3.10.2 python 3.13
+```

--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -10,11 +10,11 @@ RUN yum update -y && \
     yum clean all && \
     rm -rf /var/cache/yum /var/lib/yum/history
 
-ENV PREFIX /opt
+ENV PREFIX=/opt
 
 WORKDIR /opt
 
-ENV LD_LIBRARY_PATH $PREFIX/lib:$LD_LIBRARY_PATH
+ENV LD_LIBRARY_PATH=$PREFIX/lib:$LD_LIBRARY_PATH
 
 # pkg-config
 ENV PKGCONFIG_VERSION=0.29.2
@@ -404,7 +404,7 @@ RUN for i in $PREFIX/lib/*.so; do patchelf --force-rpath --set-rpath '$ORIGIN' $
 # Build final image
 FROM public.ecr.aws/lambda/provided:al2 AS runner
 
-ENV PREFIX /opt
+ENV PREFIX=/opt
 COPY --from=builder /opt/lib/ $PREFIX/lib/
 COPY --from=builder /opt/include/ $PREFIX/include/
 COPY --from=builder /opt/share/ $PREFIX/share/

--- a/dockerfiles/runtimes/nodejs
+++ b/dockerfiles/runtimes/nodejs
@@ -16,7 +16,7 @@ ENV \
 # When building rasterio, setup.py will get libs directoy from gdal-config
 # $ gdal-config --libs
 # -L/opt/lib -lgdal
-ENV PREFIX /opt
+ENV PREFIX=/opt
 
 COPY --from=gdal /opt/lib/ $PREFIX/lib/
 COPY --from=gdal /opt/include/ $PREFIX/include/

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,7 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+# set -x # print each command before executing
 
 GDAL_VERSION=$1
 GDAL_VERSION_TAG=${GDAL_VERSION%.*}

--- a/scripts/deploy.py
+++ b/scripts/deploy.py
@@ -33,7 +33,6 @@ CompatibleRuntimes_al2 = [
     "python3.12",
     "python3.11",
     "python3.10",
-    "python3.9",
     "java21",
     "java17",
     "java11",


### PR DESCRIPTION
Few issues currently:

1) gdal 3.9 and 3.10 won't build on the public.ecr.aws/lambda/provided:al image -- they need to use al2023 image instead.
2) al2023 uses dnf instead of yum, but the commands are the same
3) install package automake instead of automake16 
4) GDAL docs state to build with commands
```
  && cmake --build . \
  && cmake --build . --target install \
```

instead of 

```
  && make -j $(nproc) --silent && make install 
```